### PR TITLE
Add a console message when server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Backend service that calls APIs for the front-end clinical-trial-matching-engine
 
 1. Create a file named `.env.local` and add `TRIALSCOPE_TOKEN=<api_token>` to the top of the file and save
 2. Run `npm install`
-3. Run `node server.js`
-4. The service will now be running at http://localhost:3000
+3. Run `node server.js` (or `npm start`)
+4. The service will now be running at http://localhost:3000/
 
 # Lint and tests
 

--- a/env.js
+++ b/env.js
@@ -6,9 +6,9 @@ class configuration {
   }
   defaultEnvObject() {
     return {
-      port : this.PORT,
-      token : this.TOKEN,
-      trialscope_endpoint : this.TRIALSCOPE_ENDPOINT
+      port: this.PORT,
+      token: this.TOKEN,
+      trialscope_endpoint: this.TRIALSCOPE_ENDPOINT
     };
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "lint": "eslint *.js",
+    "start": "node ./server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/server.js
+++ b/server.js
@@ -60,4 +60,5 @@ app.post('/getClinicalTrial', function(req, res) {
     });
 });
 
+console.log(`Starting server on port ${enviroment.port}...`);
 app.listen(enviroment.port);


### PR DESCRIPTION
This is just some fairly minor tweaks - in addition to printing out the port the service is starting on (to make it clear that something actually happened when you run the server), this adds a script to `package.json` to allow using `npm start` to start the server and has some minor style tweaks to `env.js`. It also updates the `README.md` file to indicate that `npm start` works.