### PR TITLE
Update codecov (actually istanbul) configuration

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,5 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "include": [ "dist-spec/**/*.js", "src/**/*.ts" ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -295,6 +295,15 @@
         }
       }
     },
+    "@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
+      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2"
+      }
+    },
     "@istanbuljs/schema": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "xml2json": "^0.12.0"
   },
   "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/express": "^4.17.6",
     "@types/jasmine": "^3.5.10",
     "@types/node": "^14.0.13",


### PR DESCRIPTION
This updates the Istanbul configuration to enable TypeScript-specific configuration as well as limit the covered code to the actual code and not the tests. (Some tests have branches that shouldn't execute but exist to handle possible error conditions.)