### PR TITLE
Update to use latest service library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,13 +1362,14 @@
     },
     "node_modules/clinical-trial-matching-service": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
+      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#49a38a4dfdbf623c2631a96059fd19be9d74603c",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "extract-zip": "^2.0.1",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "yauzl": "^2.10.0"
       }
     },
     "node_modules/cliui": {
@@ -2334,7 +2335,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -3811,9 +3811,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7498,13 +7495,14 @@
       "dev": true
     },
     "clinical-trial-matching-service": {
-      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
+      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#49a38a4dfdbf623c2631a96059fd19be9d74603c",
       "from": "clinical-trial-matching-service@github:mcode/clinical-trial-matching-service",
       "requires": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "extract-zip": "^2.0.1",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "yauzl": "^2.10.0"
       }
     },
     "cliui": {

--- a/spec/trialscope.spec.ts
+++ b/spec/trialscope.spec.ts
@@ -6,7 +6,7 @@ import {
   TrialScopeServerError,
   TrialScopeTrial
 } from '../src/trialscope';
-import { fhir, ClinicalTrialGovService, ResearchStudy } from 'clinical-trial-matching-service';
+import { fhir, ClinicalTrialsGovService, ResearchStudy } from 'clinical-trial-matching-service';
 // For spying purposes:
 import nock from 'nock';
 
@@ -244,12 +244,12 @@ describe('TrialScopeQuery', () => {
 
 describe('TrialScopeQueryRunner', () => {
   let queryRunner: TrialScopeQueryRunner;
-  let backupService: ClinicalTrialGovService;
+  let backupService: ClinicalTrialsGovService;
   let scope: nock.Scope;
   let interceptor: nock.Interceptor;
 
   beforeEach(() => {
-    backupService = new ClinicalTrialGovService('tmp');
+    backupService = new ClinicalTrialsGovService('tmp');
     queryRunner = new TrialScopeQueryRunner('https://example.com/trialscope', 'token', backupService);
     scope = nock('https://example.com');
     interceptor = scope.post('/trialscope');

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import TrialScopeQueryRunner from './trialscope';
 
 import {
   fhir,
-  ClinicalTrialGovService,
+  ClinicalTrialsGovService,
   ClinicalTrialMatchingService,
   configFromEnv
 } from 'clinical-trial-matching-service';
@@ -11,7 +11,7 @@ import * as dotenv from 'dotenv-flow';
 
 export class TrialScopeService extends ClinicalTrialMatchingService {
   queryRunner: TrialScopeQueryRunner;
-  backupService: ClinicalTrialGovService;
+  backupService: ClinicalTrialsGovService;
 
   constructor(config: Record<string, string | number>) {
     super((patientBundle: fhir.Bundle) => {
@@ -23,7 +23,7 @@ export class TrialScopeService extends ClinicalTrialMatchingService {
     if (!config.token) throw new Error('Missing configuration value for TRIALSCOPE_TOKEN');
 
     // TODO: Make this configurable
-    this.backupService = new ClinicalTrialGovService('clinicaltrial-backup-cache');
+    this.backupService = new ClinicalTrialsGovService('clinicaltrial-backup-cache');
     this.queryRunner = new TrialScopeQueryRunner(
       config.endpoint.toString(),
       config.token.toString(),

--- a/src/trialscope.ts
+++ b/src/trialscope.ts
@@ -1,7 +1,7 @@
 /**
  * Module for running queries via TrialScope
  */
-import { ClinicalTrialGovService, ServerError } from 'clinical-trial-matching-service';
+import { ClinicalTrialsGovService, ServerError } from 'clinical-trial-matching-service';
 import https from 'https';
 import { IncomingMessage } from 'http';
 import { convertTrialScopeToResearchStudy } from './research-study-mapping';
@@ -330,7 +330,7 @@ export class TrialScopeQuery {
 }
 
 export class TrialScopeQueryRunner {
-  constructor(public endpoint: string, private token: string, private backupService: ClinicalTrialGovService) {}
+  constructor(public endpoint: string, private token: string, private backupService: ClinicalTrialsGovService) {}
 
   runQuery(patientBundle: fhir.Bundle): Promise<SearchSet> {
     // update for advanced matches query


### PR DESCRIPTION
Updates to use the version of the service library which caches clinical trial data to the file system.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrappers template?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
